### PR TITLE
Disabled class typo

### DIFF
--- a/jquery.stylish-select.js
+++ b/jquery.stylish-select.js
@@ -83,7 +83,7 @@
             var opts = $.extend(defaults, options),
                 $input = $(this),
                 $containerDivText    = $('<div class="selectedTxt"></div>'),
-                $containerDiv        = $('<div class="newListSelected ' + opts.containerClass + ($input.is(':disabled') ? 'newListDisabled' : '') + '"></div>'),
+                $containerDiv        = $('<div class="newListSelected ' + opts.containerClass + ($input.is(':disabled') ? ' newListDisabled' : '') + '"></div>'),
                 $containerDivWrapper = $('<div class="SSContainerDivWrapper" style="visibility:hidden;"></div>'),
                 $newUl               = $('<ul class="newList"></ul>'),
                 currentIndex         = -1,


### PR DESCRIPTION
Thanks for such a great plugin!

A space is needed before the 'disabled' class is appended to the list of classes, otherwise `newListDisabled` will be combined with user specified classes.
