### PR TITLE
added condition on keypress event

### DIFF
--- a/jquery.stylish-select.js
+++ b/jquery.stylish-select.js
@@ -353,7 +353,7 @@
 
                     var currentKeyIndex = keys.indexOf(keyPressed);
 
-                    if (typeof currentKeyIndex != 'undefined'){ //if key code found in array
+                    if (typeof currentKeyIndex != 'undefined' && currentKeyIndex >= 0){ //if key code found in array
                         ++currentIndex;
                         currentIndex = keys.indexOf(keyPressed, currentIndex); //search array from current index
 


### PR DESCRIPTION
adding this condition to catch if the currentKeyIndex  is greater than or equal to 0 so that the logic inside won't execute

scenario:
My list has
* Select Item
* Apple
* Maple
* Zipper

so my keys are ['s', 'a', 'm', 'z']

but when I press other keys that isn't in the list
the logic still executes and selected the index 1 or the 2nd item in the list

and when I added currentKeyIndex >= 0 in line 356
the logic only runs when I press 's', 'a', 'm' or 'z'

I hope this will be approved or you could give me some workaround

thanks